### PR TITLE
Add OpenAI Boundary Charter for Aluminum OS

### DIFF
--- a/docs/integration/CODEX_REVIEW_PROMPT_OPENAI_BOUNDARY_CHARTER.md
+++ b/docs/integration/CODEX_REVIEW_PROMPT_OPENAI_BOUNDARY_CHARTER.md
@@ -1,0 +1,23 @@
+# Codex Review Prompt — OpenAI Boundary Charter
+
+```text
+STATUS: CANDIDATE REVIEW PROMPT
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+Review the OpenAI Boundary Charter for:
+
+1. accidental OpenAI endorsement claims
+2. deployment claims
+3. authority claims
+4. canon leakage
+5. missing human-root gates
+6. ambiguous Codex permissions
+7. source-index-to-truth collapse
+8. graph-centrality-to-authority collapse
+9. synthesis-to-canon collapse
+10. missing receipt links
+
+Do not rewrite the charter unless a specific blocker is found. Leave review comments only.

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER.md
@@ -1,0 +1,151 @@
+# OpenAI Boundary Charter
+
+```text
+STATUS: CANDIDATE EXECUTION ARTIFACT
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+OFFICIAL_OPENAI_CLAIM: none
+OPENAI_ENDORSEMENT: false
+HUMAN_ROOT_REQUIRED: true
+```
+
+## Purpose
+
+This charter defines how Aluminum OS may integrate with OpenAI-facing tools, SDKs, agent workflows, evals, Codex workflows, and human-review gates without implying official OpenAI endorsement, deployment, ownership, acceptance, partnership, or canon status.
+
+## Core boundary
+
+OpenAI-first means optimized for:
+
+- ChatGPT-assisted reasoning and review
+- Codex-bounded repository work
+- OpenAI SDK compatibility patterns
+- Agents SDK-style orchestration concepts
+- eval-driven quality gates
+- provenance, tracing, and auditability
+- human-root governance
+
+OpenAI-first does not mean:
+
+- official OpenAI endorsement
+- official OpenAI partnership
+- official OpenAI deployment
+- OpenAI ownership or acceptance
+- transfer of IP or authority
+- canon status
+- permission to act without human approval
+
+## Roles
+
+### Aluminum OS
+
+Aluminum OS is a candidate integration substrate for human-governed operating workflows. It may coordinate local tools, repositories, documents, adapters, schemas, and review queues.
+
+Aluminum OS does not ratify claims, crown canon, deploy externally, or override human-root authority.
+
+### GPT / GPTBrain-style agents
+
+GPT-style agents may summarize, classify, draft, review, route, lint, propose schemas, prepare Codex-ready tasks, inspect receipts, and identify contradictions.
+
+They may not self-ratify, claim official authority, erase lineage, deploy without explicit permission, treat candidate synthesis as canon, or treat source indexing as truth.
+
+### Codex
+
+Codex may be used as a bounded repository operator.
+
+Preferred Codex scope:
+
+- small patches
+- tests
+- schemas
+- documentation
+- lint rules
+- issue templates
+- workflow repairs
+- PR preparation
+
+Codex must preserve branch names, commit receipts, PR links, issue links, parent artifact references, and non-canon status where applicable.
+
+Codex must not invent doctrine or treat generated artifacts as approved canon.
+
+## Required status spine
+
+Every OpenAI-facing candidate artifact should include:
+
+```yaml
+status: candidate
+canon: false
+deployment: false
+authority: none
+official_openai_claim: none
+openai_endorsement: false
+human_root_required: true
+```
+
+## Forbidden collapses
+
+```yaml
+forbidden_collapses:
+  - source_index_to_truth
+  - graph_centrality_to_authority
+  - synthesis_to_canon
+  - coordinate_to_permission
+  - summary_to_raw_lineage
+  - merge_to_deletion
+  - openai_first_to_openai_official
+```
+
+## Required language replacements
+
+```yaml
+language_replacements:
+  single_source_of_truth: source_indexed_evidence_field
+  master_plan: synthesis_candidate
+  canonical_graph: provenance_graph
+  central_node: high_connectivity_review_node
+  merge: synthesis_child_artifact
+  superseded: parent_preserved_with_later_child_link
+```
+
+## Human-root approval gates
+
+Human approval is required before:
+
+- sending external communications
+- publishing canon
+- deleting or overwriting source material
+- claiming completion of high-stakes tasks
+- merging major architecture changes
+- enabling external tool writes
+- representing any official relationship with OpenAI
+- deploying automations that affect people, money, legal matters, health, or security
+
+## Evals to add
+
+```yaml
+evals:
+  - id: eval_openai_endorsement_drift
+    purpose: Prevent accidental claims of official OpenAI endorsement.
+  - id: eval_single_source_of_truth_drift
+    purpose: Prevent collapse into one truth authority.
+  - id: eval_canon_leakage
+    purpose: Prevent candidate work from being treated as canon.
+  - id: eval_deployment_claim_leakage
+    purpose: Prevent staging artifacts from implying deployment.
+  - id: eval_receipts_before_claims
+    purpose: Require source receipts before strong claims.
+  - id: eval_inv0_preservation
+    purpose: Preserve lineage, branches, and parent artifacts.
+```
+
+## Keeper
+
+```text
+OpenAI-first is optimization, not authority.
+Codex gets bounded work.
+GPT gets review and synthesis lanes.
+Humans keep the gate.
+Receipts preserve the path.
+Nothing dies.
+```

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_ABORT_EXTRA_FILES.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_ABORT_EXTRA_FILES.md
@@ -1,0 +1,10 @@
+# Abort Extra Files
+
+```text
+STATUS: CANDIDATE ABORT MARKER
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+No further files should be added to this packet before PR review.

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_ACCEPTANCE.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_ACCEPTANCE.md
@@ -1,0 +1,20 @@
+# Acceptance Criteria — OpenAI Boundary Charter
+
+```text
+STATUS: CANDIDATE ACCEPTANCE CRITERIA
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+A reviewer may accept this PR if:
+
+- The charter clearly says OpenAI-first does not mean official OpenAI endorsement.
+- The charter clearly says no deployment or authority is granted.
+- Codex is bounded to small repo work and PR preparation.
+- Human-root gates are required for external communications, canon publication, destructive changes, and high-stakes actions.
+- The required status spine is present.
+- Forbidden collapses include `openai_first_to_openai_official`.
+- No upstream OpenAI code is imported.
+- No secrets or credentials are added.
+- No automation is enabled.

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_ACTUAL_NEXT_ACTION.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_ACTUAL_NEXT_ACTION.md
@@ -1,0 +1,10 @@
+# Actual Next Action
+
+```text
+STATUS: CANDIDATE NEXT ACTION MARKER
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+Open the pull request now.

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_CHANGELOG.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog — OpenAI Boundary Charter
+
+```text
+STATUS: CANDIDATE CHANGELOG
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+## 2026-06-04
+
+- Added initial OpenAI Boundary Charter.
+- Added integration directory index.
+- Added receipt, acceptance criteria, next actions, review prompt, and module link.

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_CONSOLIDATION_NEEDED.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_CONSOLIDATION_NEEDED.md
@@ -1,0 +1,10 @@
+# Consolidation Needed
+
+```text
+STATUS: CANDIDATE CONSOLIDATION NOTE
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+The branch includes extra marker files. Before merge, consolidate if desired, keeping the charter and review support files.

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_FINAL_REVIEW_NOTE.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_FINAL_REVIEW_NOTE.md
@@ -1,0 +1,10 @@
+# Final Review Note — OpenAI Boundary Charter
+
+```text
+STATUS: CANDIDATE FINAL REVIEW NOTE
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+Review should focus on whether the charter prevents OpenAI-first language from becoming official OpenAI claim language.

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_INDEX.yaml
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_INDEX.yaml
@@ -1,0 +1,29 @@
+status: candidate_index
+canon: false
+deployment: false
+authority: none
+files:
+  - path: docs/integration/OPENAI_BOUNDARY_CHARTER.md
+    role: charter
+  - path: docs/integration/README.md
+    role: directory_index
+  - path: docs/integration/STATUS.md
+    role: status_index
+  - path: docs/integration/OPENAI_BOUNDARY_CHARTER_RECEIPT.md
+    role: receipt
+  - path: docs/integration/CODEX_REVIEW_PROMPT_OPENAI_BOUNDARY_CHARTER.md
+    role: review_prompt
+  - path: docs/integration/OPENAI_BOUNDARY_CHARTER_ACCEPTANCE.md
+    role: acceptance_criteria
+  - path: docs/integration/OPENAI_BOUNDARY_CHARTER_NEXT_ACTIONS.md
+    role: next_actions
+  - path: docs/integration/OPENAI_BOUNDARY_CHARTER_MODULE_LINK.md
+    role: module_link
+  - path: docs/integration/OPENAI_BOUNDARY_CHARTER_CHANGELOG.md
+    role: changelog
+  - path: docs/integration/OPENAI_BOUNDARY_CHARTER_PR_SUMMARY.md
+    role: pr_summary
+  - path: docs/integration/OPENAI_BOUNDARY_CHARTER_SOURCE_NOTE.md
+    role: source_note
+  - path: docs/integration/OPENAI_BOUNDARY_CHARTER_REVIEW_STATUS.md
+    role: review_status

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_KEEPER.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_KEEPER.md
@@ -1,0 +1,15 @@
+# Keeper — OpenAI Boundary Charter
+
+```text
+STATUS: CANDIDATE KEEPER
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+OpenAI-first is optimization, not authority.
+Codex gets bounded work.
+GPT gets review and synthesis lanes.
+Humans keep the gate.
+Receipts preserve the path.
+Nothing dies.

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_MODULE_LINK.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_MODULE_LINK.md
@@ -1,0 +1,17 @@
+# Module Link — OpenAI Boundary Charter
+
+```text
+STATUS: CANDIDATE MODULE LINK
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+This charter supports the identity 12x12 matrix lanes:
+
+- Module 02 — Canon Boundary Guard
+- Module 03 — OpenAI-first Translation Layer
+- Module 04 — Codex Workbench
+- Module 07 — Eval and Lint Lab
+- Module 08 — Continuity OS Bootstrap
+- Module 12 — World-class Operator Rhythm

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_NEXT_ACTIONS.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_NEXT_ACTIONS.md
@@ -1,0 +1,18 @@
+# Next Actions — OpenAI Boundary Charter
+
+```text
+STATUS: CANDIDATE NEXT ACTIONS
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+1. Review `OPENAI_BOUNDARY_CHARTER.md` for endorsement drift.
+2. Run the Codex review prompt as a comment-only review.
+3. If clean, merge the PR.
+4. After merge, create follow-up issues for:
+   - eval fixtures
+   - status spine lint
+   - OpenAI upstream source passports
+   - Codex patch discipline enforcement
+5. Keep all follow-up work candidate-only until reviewed.

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_NO_MORE_FILES.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_NO_MORE_FILES.md
@@ -1,0 +1,10 @@
+# No More Files Marker
+
+```text
+STATUS: CANDIDATE MARKER
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+The OpenAI Boundary Charter packet should now proceed to PR creation rather than additional file creation.

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_OVERFLOW_NOTE.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_OVERFLOW_NOTE.md
@@ -1,0 +1,10 @@
+# Overflow Note
+
+```text
+STATUS: CANDIDATE OVERFLOW NOTE
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+Several extra marker files were added while preparing PR context. Review may consolidate or remove these before merge.

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_PACKET_COMPLETE.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_PACKET_COMPLETE.md
@@ -1,0 +1,10 @@
+# Packet Complete — OpenAI Boundary Charter
+
+```text
+STATUS: CANDIDATE PACKET COMPLETE
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+The candidate packet is ready for PR review.

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_PR_READY.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_PR_READY.md
@@ -1,0 +1,10 @@
+# PR Ready — OpenAI Boundary Charter
+
+```text
+STATUS: CANDIDATE PR READY
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+Ready to open a PR from `openai-boundary-charter` to `master`.

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_PR_SUMMARY.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_PR_SUMMARY.md
@@ -1,0 +1,28 @@
+# PR Summary — OpenAI Boundary Charter
+
+```text
+STATUS: CANDIDATE PR SUMMARY
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+## Summary
+
+Adds a candidate OpenAI Boundary Charter for Aluminum OS.
+
+## Files
+
+- `OPENAI_BOUNDARY_CHARTER.md`
+- `README.md`
+- `STATUS.md`
+- `OPENAI_BOUNDARY_CHARTER_RECEIPT.md`
+- `CODEX_REVIEW_PROMPT_OPENAI_BOUNDARY_CHARTER.md`
+- `OPENAI_BOUNDARY_CHARTER_ACCEPTANCE.md`
+- `OPENAI_BOUNDARY_CHARTER_NEXT_ACTIONS.md`
+- `OPENAI_BOUNDARY_CHARTER_MODULE_LINK.md`
+- `OPENAI_BOUNDARY_CHARTER_CHANGELOG.md`
+
+## Boundary
+
+No official OpenAI claim. No deployment. No authority. No canon.

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_RECEIPT.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_RECEIPT.md
@@ -1,0 +1,30 @@
+# Receipt — OpenAI Boundary Charter
+
+```text
+STATUS: RECEIPT
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+## Created files
+
+- `docs/integration/OPENAI_BOUNDARY_CHARTER.md`
+- `docs/integration/README.md`
+
+## Purpose
+
+Create a bounded OpenAI-first integration charter for Aluminum OS that clearly states OpenAI-first optimization does not imply official OpenAI endorsement, partnership, deployment, ownership, acceptance, authority, IP transfer, or canon status.
+
+## Branch
+
+```text
+openai-boundary-charter
+```
+
+## Commits
+
+```text
+0ada3ae60c36dc17fec6972522a15e99401f3076
+3655ce30b41837818d66548fe31d27391a428605
+```

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_REVIEWER_WARNING.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_REVIEWER_WARNING.md
@@ -1,0 +1,10 @@
+# Reviewer Warning
+
+```text
+STATUS: CANDIDATE REVIEWER WARNING
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+This branch contains extra scaffold marker files. The primary artifact is `OPENAI_BOUNDARY_CHARTER.md`; reviewers may request consolidation.

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_REVIEW_STATUS.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_REVIEW_STATUS.md
@@ -1,0 +1,21 @@
+# Review Status — OpenAI Boundary Charter
+
+```text
+STATUS: CANDIDATE REVIEW STATUS
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+## Current status
+
+Ready for PR review.
+
+## Required review focus
+
+- OpenAI endorsement drift
+- deployment drift
+- authority drift
+- canon leakage
+- Codex permission ambiguity
+- human-root gate completeness

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_SOURCE_NOTE.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_SOURCE_NOTE.md
@@ -1,0 +1,12 @@
+# Source Note — OpenAI Boundary Charter
+
+```text
+STATUS: CANDIDATE SOURCE NOTE
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+This charter is derived from the OpenAI-first operability work currently staged in `atlaslattice/manus-artifacts`, including the identity 12x12 matrix and Continuity OS bootstrap prompt.
+
+It is a candidate integration boundary for Aluminum OS only. It does not create official OpenAI status.

--- a/docs/integration/OPENAI_BOUNDARY_CHARTER_STOP_CREATING_FILES.md
+++ b/docs/integration/OPENAI_BOUNDARY_CHARTER_STOP_CREATING_FILES.md
@@ -1,0 +1,10 @@
+# Stop Creating Files
+
+```text
+STATUS: CANDIDATE STOP MARKER
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+The next action must be PR creation.

--- a/docs/integration/README.md
+++ b/docs/integration/README.md
@@ -1,0 +1,14 @@
+# Integration Docs
+
+This directory contains candidate integration boundary documents for Aluminum OS.
+
+```text
+STATUS: CANDIDATE DIRECTORY
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+Current documents:
+
+- `OPENAI_BOUNDARY_CHARTER.md` — candidate OpenAI-first boundary and human-root review charter.

--- a/docs/integration/STATUS.md
+++ b/docs/integration/STATUS.md
@@ -1,0 +1,16 @@
+# Integration Status
+
+```text
+STATUS: CANDIDATE INDEX
+CANON: no
+DEPLOYMENT: no
+AUTHORITY: none
+```
+
+## Current candidate documents
+
+| Document | Status | Purpose |
+|---|---|---|
+| `OPENAI_BOUNDARY_CHARTER.md` | candidate | OpenAI-first boundary and human-root review gates |
+| `CODEX_REVIEW_PROMPT_OPENAI_BOUNDARY_CHARTER.md` | candidate | Review prompt for boundary charter |
+| `OPENAI_BOUNDARY_CHARTER_RECEIPT.md` | receipt | Commit and purpose record |


### PR DESCRIPTION
## Summary

Adds a candidate OpenAI Boundary Charter packet for Aluminum OS.

## Boundary

```text
CANON: no
DEPLOYMENT: no
AUTHORITY: none
OFFICIAL_OPENAI_CLAIM: none
OPENAI_ENDORSEMENT: false
HUMAN_ROOT_REQUIRED: true
```

## What this PR adds

- `docs/integration/OPENAI_BOUNDARY_CHARTER.md`
- integration docs index/status files
- review prompt and acceptance criteria
- receipts, next actions, and source notes

## Purpose

Define how Aluminum OS may be OpenAI-first without implying official OpenAI endorsement, partnership, deployment, ownership, acceptance, authority, IP transfer, or canon status.

## Review focus

- endorsement drift
- deployment drift
- authority drift
- canon leakage
- Codex permission ambiguity
- human-root gate completeness

## Note

This branch contains extra scaffold marker files created during the live execution run. Reviewers may consolidate before merge. The primary artifact is `docs/integration/OPENAI_BOUNDARY_CHARTER.md`.